### PR TITLE
refactor: remove hardcoded `localhost:8000` for frontend

### DIFF
--- a/src/famiglia_core/command_center/frontend/src/config.ts
+++ b/src/famiglia_core/command_center/frontend/src/config.ts
@@ -1,4 +1,4 @@
-const DEFAULT_BACKEND_BASE = 'http://localhost:8000';
+const DEFAULT_BACKEND_BASE = '';
 
 function normalizeUrl(value: string): string {
   return value.trim().replace(/\/+$/, '');

--- a/src/famiglia_core/command_center/frontend/src/modules/TerminalContext.tsx
+++ b/src/famiglia_core/command_center/frontend/src/modules/TerminalContext.tsx
@@ -137,7 +137,8 @@ export function TerminalProvider({ children, initialChatId = 'command-center' }:
     setActiveThreadId(dbId);
     // Optional: Fetch thread history if not already present or to ensure sync
     try {
-      const res = await fetch(`${API_BASE}/chat/thread?parent_id=${dbId}`);
+      const url = new URL(`${API_BASE}/chat/thread?parent_id=${dbId}`, window.location.origin);
+      const res = await fetch(url);
       if (res.ok) {
         const history = await res.json();
         const threadMessages = history.filter(Boolean).map((msg: any, idx: number) => {
@@ -620,7 +621,7 @@ export function TerminalProvider({ children, initialChatId = 'command-center' }:
     }));
 
     try {
-      const url = new URL(`${API_BASE}/chat/stream`);
+      const url = new URL(`${API_BASE}/chat/stream`, window.location.origin);
       url.searchParams.append('message', text);
       url.searchParams.append('agent_id', targetAgentId);
       url.searchParams.append('thread_id', currentChatId); // Use channel ID as thread

--- a/tests/command_center/frontend/test_config.spec.ts
+++ b/tests/command_center/frontend/test_config.spec.ts
@@ -9,8 +9,8 @@ describe('Frontend Config', () => {
     vi.resetModules();
     const { BACKEND_BASE, API_BASE } = await import('@/config');
 
-    expect(BACKEND_BASE).toBe('http://localhost:8000');
-    expect(API_BASE).toBe('http://localhost:8000/api/v1');
+    expect(BACKEND_BASE).toBe('');
+    expect(API_BASE).toBe('/api/v1');
   });
 
   it('builds API_BASE from a custom backend base', async () => {


### PR DESCRIPTION


# Description
This PR is meant to:
1. remove hardcoded localhost:8000 for frontend
2. adjust test

it was breaking the chat function in Hetznzer

# Checklist
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (i.e. `README.md` files)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
