### PR TITLE
feat: enhance Ollama API key resolution and improve web search error handling

### DIFF
--- a/src/famiglia_core/agents/orchestration/features/README.md
+++ b/src/famiglia_core/agents/orchestration/features/README.md
@@ -27,7 +27,7 @@ The orchestration layer enforces a **Proactive Model Resolution** strategy. Befo
 Located in `market_research/`, focused on external intelligence and strategic ideation.
 
 ### 1. Market Research Workflow
-Performs iterative web searches, curates insights into the **Intelligence Center**, and generates innovative business proposals.
+Performs iterative web searches, curates insights into the **Intelligence Center**, generates innovative business proposals, and delivers results to the **Directive Terminal** (with an optional Slack notification to #Research-Insights).
 - **File:** `market_research/market_research.py`
 - **Tests:** `tests/agents/test_orchestration_features.py` (100% Logic Coverage)
 - **Workflow Architecture:**
@@ -39,7 +39,7 @@ graph TD;
     curate_results(curate_results)
     save_to_intelligence(save_to_intelligence)
     generate_ideas(generate_ideas)
-    notify_slack(notify_slack)
+    deliver_results(deliver_results)
     __end__([__end__]):::last
 
     __start__ --> perform_search;
@@ -48,8 +48,8 @@ graph TD;
     perform_search -- "Success / Final Attempt" --> curate_results;
     curate_results --> save_to_intelligence;
     save_to_intelligence --> generate_ideas;
-    generate_ideas --> notify_slack;
-    notify_slack --> __end__;
+    generate_ideas --> deliver_results;
+    deliver_results --> __end__;
 
     classDef default fill:#f2f0ff,line-height:1.2
     classDef first fill-opacity:0

--- a/src/famiglia_core/agents/orchestration/features/market_research/market_research.py
+++ b/src/famiglia_core/agents/orchestration/features/market_research/market_research.py
@@ -45,7 +45,7 @@ class MarketResearchWorkflow:
     def _extract_research_goal(self, task: str) -> str:
         """Isolate the actual research topic from meta-prompts or directive wrappers."""
         if not task: return "General Market Research"
-        
+
         # 1. Handle Situation Room "Client Specification:" format
         if "Client Specification:" in task:
             parts = task.split("Client Specification:")
@@ -53,12 +53,15 @@ class MarketResearchWorkflow:
                 spec = parts[1].strip()
                 if spec: return spec
 
-        # 2. Handle "Executing graph market_research" boilerplate
-        # Remove the boilerplate to find pure topic if it exists
-        clean_task = task.replace("Executing graph market_research", "").strip()
+        # 2. Strip autonomous queue metadata wrapper (everything after \n\nTask metadata:)
+        import re
+        clean_task = re.split(r'\n\n(?:Task metadata|Execution constraints):', task)[0].strip()
+
+        # 3. Handle "Executing graph market_research" boilerplate
+        clean_task = clean_task.replace("Executing graph market_research", "").strip()
         if clean_task and len(clean_task) > 5:
             return clean_task
-            
+
         return task
 
     def _load_rossini_personality(self) -> str:

--- a/src/famiglia_core/agents/orchestration/features/market_research/market_research.py
+++ b/src/famiglia_core/agents/orchestration/features/market_research/market_research.py
@@ -55,11 +55,11 @@ class MarketResearchWorkflow:
 
         # 2. Strip autonomous queue metadata wrapper (everything after \n\nTask metadata:)
         import re
-        clean_task = re.split(r'\n\n(?:Task metadata|Execution constraints):', task)[0].strip()
+        clean_task = re.split(r'\n\s*\n\s*(?:Task metadata|Execution constraints):', task, flags=re.IGNORECASE)[0].strip()
 
         # 3. Handle "Executing graph market_research" boilerplate
         clean_task = clean_task.replace("Executing graph market_research", "").strip()
-        if clean_task and len(clean_task) > 5:
+        if clean_task:
             return clean_task
 
         return task

--- a/src/famiglia_core/agents/orchestration/features/market_research/market_research.py
+++ b/src/famiglia_core/agents/orchestration/features/market_research/market_research.py
@@ -323,9 +323,9 @@ class MarketResearchWorkflow:
                 
         return state
 
-    def notify_slack(self, state: MarketResearchState) -> MarketResearchState:
-        """Node 5: Post an update in Slack (#Research-Insights channel)."""
-        print(f"[{self.name}] Research Node: notify_slack")
+    def deliver_results(self, state: MarketResearchState) -> MarketResearchState:
+        """Node 5: Set final_response for the Directive Terminal and optionally notify Slack."""
+        print(f"[{self.name}] Research Node: deliver_results")
         
         channel = state.get("slack_channel") or "C0AGQPGNP09" # #Research-Insights
         topic = state.get("research_topic") or state.get("task")
@@ -402,8 +402,8 @@ def setup_market_research_graph(agent):
     workflow.add_node("save_to_intelligence", workflow_logic.save_to_intelligence)
     # workflow.add_node("fix_notion_error", workflow_logic.fix_notion_error)
     workflow.add_node("generate_ideas", workflow_logic.generate_ideas)
-    workflow.add_node("notify_slack", workflow_logic.notify_slack)
-    
+    workflow.add_node("deliver_results", workflow_logic.deliver_results)
+
     def route_search(state: MarketResearchState):
         if state.get("search_success"):
             return "success"
@@ -444,8 +444,8 @@ def setup_market_research_graph(agent):
     # )
     # workflow.add_edge("fix_notion_error", "save_to_notion")
     
-    workflow.add_edge("generate_ideas", "notify_slack")
-    workflow.add_edge("notify_slack", END)
+    workflow.add_edge("generate_ideas", "deliver_results")
+    workflow.add_edge("deliver_results", END)
     
     workflow.set_entry_point("perform_search")
     

--- a/src/famiglia_core/agents/tools/web_search.py
+++ b/src/famiglia_core/agents/tools/web_search.py
@@ -13,12 +13,26 @@ class WebSearchClient:
     def __init__(self):
         self.api_key = os.getenv("OLLAMA_API_KEY", "")
 
+    def _resolve_api_key(self) -> str:
+        """Return the API key from env var or, as fallback, from the user_connections table."""
+        if self.api_key:
+            return self.api_key
+        try:
+            from famiglia_core.db.tools.user_connections_store import user_connections_store
+            conn = user_connections_store.get_connection("ollama")
+            if conn and conn.get("access_token"):
+                return conn["access_token"]
+        except Exception as e:
+            print(f"[WebSearch] Could not fetch Ollama key from DB: {e}")
+        return ""
+
     def search(self, query: str, agent_name: str = "", user_prompt: Optional[str] = None) -> str:
         """
         Execute a web search and return a formatted string of results.
         Checks cache first.
         """
-        if not self.api_key:
+        api_key = self._resolve_api_key()
+        if not api_key:
             return "[Web Search] OLLAMA_API_KEY is not set. Cannot perform web search."
 
         # Cache Check
@@ -36,7 +50,7 @@ class WebSearchClient:
             data=payload,
             headers={
                 "Content-Type": "application/json",
-                "Authorization": f"Bearer {self.api_key}",
+                "Authorization": f"Bearer {api_key}",
             },
             method="POST",
         )

--- a/tests/agents/test_orchestration_features.py
+++ b/tests/agents/test_orchestration_features.py
@@ -67,6 +67,62 @@ def test_market_research_save_to_intel(mock_agent, mock_services):
     assert call_args.title == "Market Research: AI"
     assert "# AI Research" in call_args.content
 
+def test_market_research_curate_results(mock_agent, mock_llm):
+    workflow = MarketResearchWorkflow(mock_agent)
+    mock_llm.return_value = ("# Curated Report", "model")
+    
+    state = MarketResearchState(
+        task="Research AI",
+        research_topic="AI",
+        search_results="Some results",
+        curated_markdown="",
+        notion_page_id="", notion_url="", business_ideas="", slack_channel=""
+    )
+    
+    new_state = workflow.curate_results(state)
+    assert new_state["curated_markdown"] == "# Curated Report"
+    assert mock_llm.called
+
+def test_market_research_save_to_intel_failure(mock_agent, mock_services):
+    workflow = MarketResearchWorkflow(mock_agent)
+    mock_services["intel_research"].create_item.side_effect = Exception("DB Timeout")
+    
+    state = MarketResearchState(
+        task="Test", 
+        research_topic="AI", 
+        curated_markdown="# AI Research", 
+        business_ideas="Idea 1",
+        search_results="", notion_page_id="", notion_url="", slack_channel=""
+    )
+    
+    new_state = workflow.save_to_intelligence(state)
+    assert new_state["db_success"] is False
+    assert "DB Timeout" in new_state["last_error"]
+    assert "FAILED" in new_state["final_response"]
+
+def test_market_research_generate_ideas(mock_agent, mock_llm):
+    workflow = MarketResearchWorkflow(mock_agent)
+    mock_llm.return_value = ("### Business Ideas\n1. AI Assistant", "model")
+    
+    state = MarketResearchState(
+        task="Research AI",
+        research_topic="AI",
+        curated_markdown="# AI Research",
+        business_ideas="",
+        search_results="", notion_page_id="", notion_url="", slack_channel=""
+    )
+    
+    new_state = workflow.generate_ideas(state)
+    assert "AI Assistant" in new_state["business_ideas"]
+
+def test_market_research_load_personality(mock_agent):
+    from unittest.mock import mock_open
+    workflow = MarketResearchWorkflow(mock_agent)
+    with patch("os.path.exists", return_value=True), \
+         patch("builtins.open", mock_open(read_data="## PERSONA & TONE\nDr. Rossini is a strategist.")):
+        personality = workflow._load_rossini_personality()
+        assert "Dr. Rossini is a strategist" in personality
+
 # --- PRD Drafting Tests ---
 
 def test_prd_drafting_understand_context(mock_agent, mock_llm):
@@ -286,3 +342,43 @@ def test_web_search_uses_db_key_for_request():
 
         called_req = mock_urlopen.call_args[0][0]
         assert called_req.get_header("Authorization") == "Bearer db-key-789"
+
+
+def test_web_search_cache_hit():
+    from famiglia_core.agents.tools.web_search import WebSearchClient
+    with patch.dict("os.environ", {"OLLAMA_API_KEY": "test-key"}):
+        client = WebSearchClient()
+        
+        with patch("famiglia_core.db.agents.context_store.context_store.get_web_search_cache") as mock_get, \
+             patch("urllib.request.urlopen") as mock_urlopen:
+            mock_get.return_value = [{"title": "Cached", "url": "http://cached.com", "content": "data"}]
+            
+            result = client.search("test query")
+            
+            assert "Cached" in result
+            mock_urlopen.assert_not_called()
+
+def test_web_search_http_error():
+    from famiglia_core.agents.tools.web_search import WebSearchClient
+    import urllib.error
+    with patch.dict("os.environ", {"OLLAMA_API_KEY": "key"}):
+        client = WebSearchClient()
+        
+        with patch("famiglia_core.db.agents.context_store.context_store.get_web_search_cache", return_value=None), \
+             patch("urllib.request.urlopen") as mock_urlopen:
+            
+            # Mock HTTPError
+            import urllib.request
+            mock_urlopen.side_effect = urllib.error.HTTPError("http://ollama.com", 500, "Internal Server Error", {}, None)
+            
+            result = client.search("test query")
+            assert "HTTP 500" in result
+
+def test_web_search_format_results():
+    from famiglia_core.agents.tools.web_search import WebSearchClient
+    client = WebSearchClient()
+    results = [{"title": "T1", "url": "U1", "content": "C1"}]
+    formatted = client._format_results("query", results)
+    assert "T1" in formatted
+    assert "U1" in formatted
+    assert "C1" in formatted

--- a/tests/agents/test_orchestration_features.py
+++ b/tests/agents/test_orchestration_features.py
@@ -195,10 +195,10 @@ def test_market_research_perform_search_failure(mock_agent, mock_services):
     assert new_state["search_success"] is False
     assert "Search API Down" in new_state["last_error"]
 
-def test_market_research_notify_slack(mock_agent, mock_llm, mock_services):
+def test_market_research_deliver_results(mock_agent, mock_llm, mock_services):
     workflow = MarketResearchWorkflow(mock_agent)
     mock_llm.return_value = ("### Ideas\n- **Idea 1**: [Link](http://test.com)", "model")
-    
+
     state = MarketResearchState(
         research_topic="AI",
         business_ideas="Some ideas",
@@ -207,12 +207,82 @@ def test_market_research_notify_slack(mock_agent, mock_llm, mock_services):
         task="Research AI",
         search_results="", curated_markdown="", notion_page_id="", notion_url="", search_retry_count=0
     )
-    
-    workflow.notify_slack(state)
-    
+
+    new_state = workflow.deliver_results(state)
+
     assert mock_services["slack_research"].post_message.called
     msg = mock_services["slack_research"].post_message.call_args[1]["message"]
-    # Check simple formatting conversions
+    # Check Markdown → Slack mrkdwn conversions
     assert "*Ideas*" in msg
     assert "*Idea 1*" in msg
     assert "<http://test.com|Link>" in msg
+    # Check final_response is set for Directive Terminal
+    assert "final_response" in new_state
+    assert "AI" in new_state["final_response"]
+
+
+def test_market_research_extract_research_goal_autonomous_queue(mock_agent):
+    """Autonomous queue wraps the real topic with metadata — ensure it is stripped."""
+    workflow = MarketResearchWorkflow(mock_agent)
+
+    task = "love\n\nTask metadata:\n- No extra metadata provided.\n\nExecution constraints:\n- Provide concise execution output."
+    assert workflow._extract_research_goal(task) == "love"
+
+    task2 = "AI Trends 2025\n\nExecution constraints:\n- This task is running from the autonomous scheduled queue."
+    assert workflow._extract_research_goal(task2) == "AI Trends 2025"
+
+
+# --- Web Search Tests ---
+
+def test_web_search_uses_env_key():
+    """When OLLAMA_API_KEY env var is set it should be used directly."""
+    from famiglia_core.agents.tools.web_search import WebSearchClient
+    with patch.dict("os.environ", {"OLLAMA_API_KEY": "env-key-123"}):
+        client = WebSearchClient()
+        assert client._resolve_api_key() == "env-key-123"
+
+
+def test_web_search_falls_back_to_db_key():
+    """When env var is absent the key should be fetched from user_connections table."""
+    from famiglia_core.agents.tools.web_search import WebSearchClient
+    with patch.dict("os.environ", {}, clear=True):
+        client = WebSearchClient()
+        # Patch the store at the module level where it is imported inside the method
+        with patch("famiglia_core.db.tools.user_connections_store.user_connections_store.get_connection") as mock_get:
+            mock_get.return_value = {"access_token": "db-key-456"}
+            key = client._resolve_api_key()
+        assert key == "db-key-456"
+
+
+def test_web_search_returns_error_when_no_key():
+    """If neither env var nor DB provides a key, search() returns the expected error string."""
+    from famiglia_core.agents.tools.web_search import WebSearchClient
+    with patch.dict("os.environ", {}, clear=True):
+        client = WebSearchClient()
+        with patch("famiglia_core.db.tools.user_connections_store.user_connections_store.get_connection", return_value=None):
+            result = client.search("test query")
+    assert "OLLAMA_API_KEY is not set" in result
+
+
+def test_web_search_uses_db_key_for_request():
+    """End-to-end: key from DB is used in the Authorization header."""
+    from famiglia_core.agents.tools.web_search import WebSearchClient
+    import urllib.request
+
+    with patch.dict("os.environ", {}, clear=True):
+        client = WebSearchClient()
+        with patch("famiglia_core.db.tools.user_connections_store.user_connections_store.get_connection",
+                   return_value={"access_token": "db-key-789"}), \
+             patch("famiglia_core.db.agents.context_store.context_store.get_web_search_cache", return_value=None), \
+             patch("urllib.request.urlopen") as mock_urlopen:
+            mock_response = MagicMock()
+            mock_response.read.return_value = b'{"results": [{"title": "T", "url": "http://x.com", "content": "c"}]}'
+            mock_response.__enter__ = lambda s: s
+            mock_response.__exit__ = MagicMock(return_value=False)
+            mock_urlopen.return_value = mock_response
+
+            with patch("famiglia_core.db.agents.context_store.context_store.set_web_search_cache"):
+                client.search("test query")
+
+        called_req = mock_urlopen.call_args[0][0]
+        assert called_req.get_header("Authorization") == "Bearer db-key-789"


### PR DESCRIPTION
# Description
This PR is meant to:
1. Make Web Search related Graphs use the stored Ollama API key instead of from the `.env` file
2. Add tests


# Checklist
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (i.e. `README.md` files)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
