### PR TITLE
fix: let Command Center check if Slack token exists already

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,4 @@ Thumbs.db
 *.njsproj
 *.sln
 data/
+scratch/

--- a/src/famiglia_core/command_center/backend/api/routes/connections.py
+++ b/src/famiglia_core/command_center/backend/api/routes/connections.py
@@ -86,15 +86,21 @@ async def test_ollama_connection():
 async def provision_slack_famiglia(payload: Dict[str, str]):
     """Trigger bulk creation of Slack apps using an App-Level Token."""
     token = payload.get("app_level_token")
-    if not token:
-        raise HTTPException(status_code=422, detail="App-Level Token is required.")
     
-    # Persist the token first so we can use it for retries/background tasks
-    user_connections_store.upsert_connection(
-        service="slack_bootstrap",
-        access_token=token,
-        username="Bootstrapper"
-    )
+    if not token:
+        # Fallback: check if we have a stored bootstrap token
+        conn = user_connections_store.get_connection("slack_bootstrap")
+        if conn and conn.get("access_token"):
+            token = conn["access_token"]
+        else:
+            raise HTTPException(status_code=422, detail="App-Level Token is required.")
+    else:
+        # Persist the new token so we can use it for retries/background tasks
+        user_connections_store.upsert_connection(
+            service="slack_bootstrap",
+            access_token=token,
+            username="Bootstrapper"
+        )
     
     from famiglia_core.command_center.backend.comms.slack.provisioning import slack_provisioning
     try:

--- a/src/famiglia_core/command_center/backend/comms/slack/provisioning.py
+++ b/src/famiglia_core/command_center/backend/comms/slack/provisioning.py
@@ -38,7 +38,7 @@ class SlackProvisioningService:
                         https_tunnel = next((t for t in tunnels if t.get("proto") == "https"), None)
                         if https_tunnel:
                             return https_tunnel.get("public_url").rstrip("/")
-                except:
+                except Exception:
                     continue
         except Exception as e:
             print(f"⚠️  Could not detect public URL: {e}")

--- a/src/famiglia_core/command_center/backend/comms/slack/provisioning.py
+++ b/src/famiglia_core/command_center/backend/comms/slack/provisioning.py
@@ -160,11 +160,31 @@ class SlackProvisioningService:
                     )
 
                     # Construct Install URL
-                    if public_url:
-                        # Direct to our bridge
-                        install_url = f"https://slack.com/oauth/v2/authorize?client_id={creds.get('client_id')}&scope=app_mentions:read,chat:write,channels:history,groups:history,im:history,reactions:write&state={agent_id}"
+                    # NOTE: api.slack.com/apps/{id}/install is DEPRECATED by Slack.
+                    # We always use the OAuth v2 authorize flow — works for both
+                    # Socket Mode and HTTP Mode apps.
+                    client_id = creds.get("client_id")
+                    scopes = "app_mentions:read,chat:write,channels:history,groups:history,im:history,reactions:write,channels:read,groups:read,im:read"
+                    if public_url and client_id:
+                        redirect_uri = f"{public_url}/api/v1/connections/auth/slack/agent/callback"
+                        install_url = (
+                            f"https://slack.com/oauth/v2/authorize"
+                            f"?client_id={client_id}"
+                            f"&scope={scopes}"
+                            f"&state={agent_id}"
+                            f"&redirect_uri={redirect_uri}"
+                        )
+                    elif client_id:
+                        # Socket Mode: no redirect URI, Slack handles install UI
+                        install_url = (
+                            f"https://slack.com/oauth/v2/authorize"
+                            f"?client_id={client_id}"
+                            f"&scope={scopes}"
+                            f"&state={agent_id}"
+                        )
                     else:
-                        install_url = f"https://api.slack.com/apps/{app_id}/install"
+                        # Last resort: app management settings page (always works)
+                        install_url = f"https://api.slack.com/apps/{app_id}"
 
                     app_info = {
                         "agent_id": agent_id,

--- a/src/famiglia_core/command_center/backend/comms/slack/provisioning.py
+++ b/src/famiglia_core/command_center/backend/comms/slack/provisioning.py
@@ -19,18 +19,29 @@ class SlackProvisioningService:
         )
 
     def _get_public_url(self) -> Optional[str]:
-        """Fetch the public URL from the ngrok container's API."""
+        """Fetch the public URL from environment or ngrok container's API."""
+        # 1. Check direct environment override first
+        env_url = os.getenv("PUBLIC_URL") or os.getenv("SLACK_REDIRECT_HOST")
+        if env_url:
+            return env_url.rstrip("/")
+
+        # 2. Try to detect from ngrok
         try:
             # We use 'ngrok' as the hostname since it's the service name in docker-compose
-            response = requests.get("http://ngrok:4040/api/tunnels", timeout=2)
-            if response.ok:
-                tunnels = response.json().get("tunnels", [])
-                # Look for the https tunnel
-                https_tunnel = next((t for t in tunnels if t.get("proto") == "https"), None)
-                if https_tunnel:
-                    return https_tunnel.get("public_url")
+            # But we also try 'localhost' if running on host
+            for host in ["ngrok", "localhost"]:
+                try:
+                    response = requests.get(f"http://{host}:4040/api/tunnels", timeout=1)
+                    if response.ok:
+                        tunnels = response.json().get("tunnels", [])
+                        # Look for the https tunnel
+                        https_tunnel = next((t for t in tunnels if t.get("proto") == "https"), None)
+                        if https_tunnel:
+                            return https_tunnel.get("public_url").rstrip("/")
+                except:
+                    continue
         except Exception as e:
-            print(f"⚠️  Could not detect ngrok tunnel: {e}")
+            print(f"⚠️  Could not detect public URL: {e}")
         return None
 
     def provision_famiglia(self, app_level_token: str = None) -> List[Dict[str, Any]]:

--- a/src/famiglia_core/command_center/backend/comms/slack/provisioning.py
+++ b/src/famiglia_core/command_center/backend/comms/slack/provisioning.py
@@ -160,12 +160,10 @@ class SlackProvisioningService:
                     )
 
                     # Construct Install URL
-                    # NOTE: api.slack.com/apps/{id}/install is DEPRECATED by Slack.
-                    # We always use the OAuth v2 authorize flow — works for both
-                    # Socket Mode and HTTP Mode apps.
                     client_id = creds.get("client_id")
                     scopes = "app_mentions:read,chat:write,channels:history,groups:history,im:history,reactions:write,channels:read,groups:read,im:read"
                     if public_url and client_id:
+                        # HTTP Mode: use full OAuth flow with redirect back to our server
                         redirect_uri = f"{public_url}/api/v1/connections/auth/slack/agent/callback"
                         install_url = (
                             f"https://slack.com/oauth/v2/authorize"
@@ -174,16 +172,10 @@ class SlackProvisioningService:
                             f"&state={agent_id}"
                             f"&redirect_uri={redirect_uri}"
                         )
-                    elif client_id:
-                        # Socket Mode: no redirect URI, Slack handles install UI
-                        install_url = (
-                            f"https://slack.com/oauth/v2/authorize"
-                            f"?client_id={client_id}"
-                            f"&scope={scopes}"
-                            f"&state={agent_id}"
-                        )
                     else:
-                        # Last resort: app management settings page (always works)
+                        # Socket Mode: the OAuth URL adds redirect_uri= (empty) which Slack rejects.
+                        # The direct app settings page has a built-in "Install to Workspace"
+                        # button that bypasses this entirely — this is the correct Dev flow.
                         install_url = f"https://api.slack.com/apps/{app_id}"
 
                     app_info = {

--- a/src/famiglia_core/command_center/frontend/src/config.ts
+++ b/src/famiglia_core/command_center/frontend/src/config.ts
@@ -8,9 +8,15 @@ const rawApiBase = import.meta.env.VITE_API_BASE;
 const rawBackendBase = import.meta.env.VITE_BACKEND_BASE;
 
 export const BACKEND_BASE = normalizeUrl(rawBackendBase || DEFAULT_BACKEND_BASE);
+
+// If BACKEND_BASE is just 'http://localhost' or 'https://localhost' without a port, 
+// it's likely a misconfiguration for local dev. We should default to relative paths 
+// so the Vite proxy can handle it.
+const isInvalidLocalhost = /^https?:\/\/localhost\/?$/.test(BACKEND_BASE);
+
 export const API_BASE = rawApiBase
   ? normalizeUrl(rawApiBase)
-  : (BACKEND_BASE ? `${BACKEND_BASE}/api/v1` : `/api/v1`);
+  : (BACKEND_BASE && !isInvalidLocalhost ? `${BACKEND_BASE}/api/v1` : `/api/v1`);
 
 // MISSION CRITICAL: Global Debug Exposure
 (window as any).DEBUG_CONFIG = {

--- a/src/famiglia_core/command_center/frontend/src/modules/Connections.tsx
+++ b/src/famiglia_core/command_center/frontend/src/modules/Connections.tsx
@@ -289,15 +289,37 @@ function SlackFamigliaWizard({ bossName }: { bossName: string }) {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [activeTab, setActiveTab] = useState<string>('');
+  const [storedTokenExists, setStoredTokenExists] = useState(false);
+  const [checkingToken, setCheckingToken] = useState(true);
 
-  const handleProvision = async () => {
+  // On mount: check if a bootstrap token is already stored in the DB
+  useEffect(() => {
+    const checkStoredToken = async () => {
+      try {
+        const res = await fetch(`${API_BASE}/connections/slack_bootstrap`);
+        if (res.ok) {
+          const data = await res.json();
+          if (data.connected) {
+            setStoredTokenExists(true);
+          }
+        }
+      } catch (e) {}
+      finally {
+        setCheckingToken(false);
+      }
+    };
+    checkStoredToken();
+  }, []);
+
+  const handleProvision = async (tokenOverride?: string) => {
+    const tokenToUse = tokenOverride ?? appLevelToken;
     setLoading(true);
     setError(null);
     try {
       const res = await fetch(`${API_BASE}/connections/slack/provision`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ app_level_token: appLevelToken }),
+        body: JSON.stringify({ app_level_token: tokenToUse || undefined }),
       });
       let data;
       try {
@@ -333,6 +355,7 @@ function SlackFamigliaWizard({ bossName }: { bossName: string }) {
       if (res.ok) setFamigliaStatus(await res.json());
     } catch (e) {}
   };
+
 
   return (
     <div className="space-y-6">
@@ -399,8 +422,38 @@ function SlackFamigliaWizard({ bossName }: { bossName: string }) {
           </div>
 
           <div className="flex flex-col gap-5 relative z-10">
+
+            {/* Stored Token Banner — shown when DB already has a token */}
+            {!checkingToken && storedTokenExists && (
+              <motion.div
+                initial={{ opacity: 0, y: -6 }}
+                animate={{ opacity: 1, y: 0 }}
+                className="p-5 bg-emerald-950/20 border border-emerald-900/40 rounded-xl flex items-center justify-between gap-4"
+              >
+                <div className="flex items-center gap-3">
+                  <span className="material-symbols-outlined text-emerald-400 text-xl">database</span>
+                  <div>
+                    <p className="text-xs font-label font-bold text-emerald-400 uppercase tracking-widest">Vault Key Found</p>
+                    <p className="text-[11px] font-body text-[#a38b88] mt-0.5">
+                      A Configuration Token is already stored. Click to re-use it — no need to paste again.
+                    </p>
+                  </div>
+                </div>
+                <button
+                  onClick={() => handleProvision()}
+                  disabled={loading}
+                  className="shrink-0 flex items-center gap-2 px-5 py-2.5 bg-emerald-950/40 border border-emerald-900/60 text-emerald-400 text-[10px] font-black font-label uppercase tracking-widest rounded-lg hover:bg-emerald-900/30 transition-all disabled:opacity-30"
+                >
+                  {loading ? <span className="material-symbols-outlined animate-spin text-base">sync</span> : <span className="material-symbols-outlined text-base">bolt</span>}
+                  Resume Session
+                </button>
+              </motion.div>
+            )}
+
             <div className="space-y-2">
-                <label className="text-[10px] font-label font-bold text-[#ffb3b5]/60 uppercase tracking-[0.3em] ml-1">Bootstrap Token</label>
+                <label className="text-[10px] font-label font-bold text-[#ffb3b5]/60 uppercase tracking-[0.3em] ml-1">
+                  {storedTokenExists ? 'Or Enter a New Token' : 'Bootstrap Token'}
+                </label>
                 <input
                   type="password"
                   placeholder="xapp-1-A123..."
@@ -410,8 +463,8 @@ function SlackFamigliaWizard({ bossName }: { bossName: string }) {
                 />
             </div>
             <button
-               onClick={handleProvision}
-               disabled={loading || !appLevelToken}
+               onClick={() => handleProvision()}
+               disabled={loading || (!appLevelToken && !storedTokenExists)}
                className="group relative w-full py-5 bg-gradient-to-r from-[#ffb3b5] to-[#f472b6] text-[#131313] font-black font-label uppercase tracking-[0.2em] rounded-xl overflow-hidden shadow-[0_10px_30px_rgba(255,179,181,0.2)] hover:shadow-[0_15px_40px_rgba(255,179,181,0.4)] transition-all disabled:opacity-30 active:scale-[0.98]"
             >
               <span className="relative z-10 flex items-center justify-center gap-3">
@@ -425,6 +478,7 @@ function SlackFamigliaWizard({ bossName }: { bossName: string }) {
               <div className="absolute inset-0 bg-white/20 opacity-0 group-hover:opacity-100 transition-opacity" />
             </button>
           </div>
+
           
         </motion.div>
       )}

--- a/src/famiglia_core/command_center/frontend/vite.config.ts
+++ b/src/famiglia_core/command_center/frontend/vite.config.ts
@@ -15,6 +15,17 @@ export default defineConfig(({ mode }) => {
       port: 80,
       strictPort: true,
       allowedHosts: true,
+      proxy: {
+        '/api': {
+          target: 'http://app:8000',
+          changeOrigin: true,
+        },
+        '/ws': {
+          target: 'http://app:8000',
+          ws: true,
+          changeOrigin: true,
+        },
+      },
       hmr: {
         clientPort: 80,
       },

--- a/tests/command_center/backend/comms/slack/test_provisioning.py
+++ b/tests/command_center/backend/comms/slack/test_provisioning.py
@@ -1,0 +1,141 @@
+import os
+import json
+import pytest
+from unittest.mock import patch, MagicMock, mock_open
+
+from slack_sdk.errors import SlackApiError
+from famiglia_core.command_center.backend.comms.slack.provisioning import SlackProvisioningService
+
+class TestSlackProvisioningService:
+
+    def setup_method(self):
+        self.service = SlackProvisioningService()
+
+    @patch.dict(os.environ, {"PUBLIC_URL": "https://custom-domain.com/"}, clear=True)
+    def test_get_public_url_from_env(self):
+        assert self.service._get_public_url() == "https://custom-domain.com"
+
+    @patch.dict(os.environ, {}, clear=True)
+    @patch("famiglia_core.command_center.backend.comms.slack.provisioning.requests.get")
+    def test_get_public_url_from_ngrok(self, mock_get):
+        mock_response = MagicMock()
+        mock_response.ok = True
+        mock_response.json.return_value = {
+            "tunnels": [{"proto": "https", "public_url": "https://ngrok-test.com/"}]
+        }
+        mock_get.return_value = mock_response
+
+        assert self.service._get_public_url() == "https://ngrok-test.com"
+
+    @patch.dict(os.environ, {}, clear=True)
+    @patch("famiglia_core.command_center.backend.comms.slack.provisioning.requests.get")
+    def test_get_public_url_fails_gracefully(self, mock_get):
+        mock_get.side_effect = Exception("Connection refused")
+        assert self.service._get_public_url() is None
+
+    @patch("famiglia_core.command_center.backend.comms.slack.provisioning.user_connections_store")
+    def test_provision_famiglia_missing_token(self, mock_store):
+        mock_store.get_connection.return_value = None
+        with pytest.raises(ValueError, match="No Slack App Configuration Token found"):
+            self.service.provision_famiglia()
+
+    @patch("famiglia_core.command_center.backend.comms.slack.provisioning.user_connections_store")
+    def test_finalize_agent(self, mock_store):
+        mock_store.upsert_connection.return_value = True
+        
+        result = self.service.finalize_agent("test_agent", "xoxb-123", "xapp-456")
+        
+        assert result is True
+        assert mock_store.upsert_connection.call_count == 2
+        
+        mock_store.upsert_connection.assert_any_call(
+            service="slack_bot:test_agent", access_token="xoxb-123"
+        )
+        mock_store.upsert_connection.assert_any_call(
+            service="slack_socket:test_agent", access_token="xapp-456"
+        )
+
+    @patch("famiglia_core.command_center.backend.comms.slack.provisioning.WebClient")
+    @patch("famiglia_core.command_center.backend.comms.slack.provisioning.user_connections_store")
+    @patch("famiglia_core.command_center.backend.comms.slack.provisioning.os.listdir")
+    def test_provision_famiglia_create_new(self, mock_listdir, mock_store, mock_web_client):
+        # Mocking finding one manifest
+        mock_listdir.return_value = ["test_agent.yaml"]
+        
+        # Mocking reading yaml
+        yaml_content = """
+display_information:
+  name: Test Agent
+settings:
+  socket_mode_enabled: true
+"""
+        with patch("builtins.open", mock_open(read_data=yaml_content)):
+            # Set up mock Slack client response
+            mock_client_instance = mock_web_client.return_value
+            mock_client_instance.apps_manifest_create.return_value = {
+                "ok": True,
+                "app_id": "A12345678",
+                "credentials": {
+                    "client_id": "client_123",
+                    "client_secret": "secret_456"
+                }
+            }
+
+            # Return empty for no existing credentials
+            mock_store.get_connection.return_value = None
+
+            # Force socket mode
+            self.service._get_public_url = MagicMock(return_value=None)
+
+            result = self.service.provision_famiglia(app_level_token="xapp-setup")
+
+            assert len(result) == 1
+            app_info = result[0]
+            assert app_info["agent_id"] == "test_agent"
+            assert app_info["app_id"] == "A12345678"
+            assert "https://api.slack.com/apps/A12345678" in app_info["install_url"]
+
+            # Ensures DB upsert was called
+            mock_store.upsert_connection.assert_called()
+
+    @patch("famiglia_core.command_center.backend.comms.slack.provisioning.WebClient")
+    @patch("famiglia_core.command_center.backend.comms.slack.provisioning.user_connections_store")
+    @patch("famiglia_core.command_center.backend.comms.slack.provisioning.os.listdir")
+    def test_provision_famiglia_update_existing_http_mode(self, mock_listdir, mock_store, mock_web_client):
+        # Mocking finding one manifest
+        mock_listdir.return_value = ["test_agent.yml"]
+        
+        # Mocking yaml content
+        yaml_content = """
+display_information:
+  name: Test Agent
+settings:
+  socket_mode_enabled: true
+"""
+        with patch("builtins.open", mock_open(read_data=yaml_content)):
+            # Force HTTP Mode by setting public URL
+            self.service._get_public_url = MagicMock(return_value="https://public.url")
+            
+            mock_client_instance = mock_web_client.return_value
+            mock_client_instance.apps_manifest_update.return_value = {"ok": True}
+
+            # Mock existing credentials in DB
+            mock_store.get_connection.return_value = {
+                "access_token": json.dumps({
+                    "app_id": "A_EXISTS",
+                    "client_id": "client_EXISTS",
+                    "client_secret": "secret_EXISTS"
+                })
+            }
+
+            result = self.service.provision_famiglia(app_level_token="xapp-setup")
+
+            assert len(result) == 1
+            app_info = result[0]
+            assert app_info["app_id"] == "A_EXISTS"
+            # It should have updated the manifest, not created
+            mock_client_instance.apps_manifest_update.assert_called_once()
+            
+            # The install URL should point to oauth because of public_url being set
+            assert "oauth/v2/authorize" in app_info["install_url"]
+            assert "client_id=client_EXISTS" in app_info["install_url"]

--- a/tests/command_center/frontend/test_vite_config.spec.ts
+++ b/tests/command_center/frontend/test_vite_config.spec.ts
@@ -1,0 +1,15 @@
+import { describe, it, expect } from 'vitest';
+import viteConfig from '../../../src/famiglia_core/command_center/frontend/vite.config';
+
+describe('Vite Config', () => {
+  it('should export a configured object', () => {
+    // Note: viteConfig may be a function depending on how defineConfig is exported.
+    // If it's the direct result or standard exported type, we can assert truthiness.
+    expect(viteConfig).toBeDefined();
+    
+    // Test that plugins are most likely configured
+    if (typeof viteConfig !== 'function' && viteConfig.plugins) {
+      expect(Array.isArray(viteConfig.plugins)).toBe(true);
+    }
+  });
+});


### PR DESCRIPTION
# Description
This PR is meant to:
1. make both frontend & backend of Slack integration in Command Center check if the Slack app configration token exist already
2. adjust tests


# Checklist
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (i.e. `README.md` files)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
