### PR TITLE
feat: standardize Slack OAuth redirect URIs and update connection status UI in dashboard

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,7 +6,7 @@ This PR is meant to:
 
 # Checklist
 - [ ] I have performed a self-review of my own code
-- [ ] I have commented my code, particularly in hard-to-understand areas
-- [ ] I have made corresponding changes to the documentation (i.e. `README.md` files)
 - [ ] I have added tests that prove my fix is effective or that my feature works
-- [ ] New and existing unit tests pass locally with my changes
+- [ ] New and existing unit tests pass **locally** with my changes
+- [ ] I have made corresponding changes to the documentation (i.e. `README.md` files)
+- [ ] I have commented my code, particularly in hard-to-understand areas

--- a/src/famiglia_core/command_center/backend/api/routes/connections.py
+++ b/src/famiglia_core/command_center/backend/api/routes/connections.py
@@ -145,7 +145,8 @@ async def get_slack_famiglia_status():
                 cdata = json.loads(creds_conn["access_token"])
                 transport = cdata.get("transport", "socket")
                 public_url = cdata.get("public_url")
-            except:
+            except (json.JSONDecodeError, KeyError, TypeError):
+                # Keep defaults when stored credentials are missing or malformed.
                 pass
 
         status[agent_id] = {

--- a/src/famiglia_core/command_center/backend/api/routes/connections.py
+++ b/src/famiglia_core/command_center/backend/api/routes/connections.py
@@ -136,7 +136,7 @@ async def get_slack_famiglia_status():
         bot_connected = bool(bot_check.get("connected"))
         socket_connected = bool(socket_check.get("connected"))
         status[agent_id] = {
-            "connected": bot_connected and socket_connected,
+            "connected": bot_connected,  # Installation is successful if bot token exists
             "bot_connected": bot_connected,
             "socket_connected": socket_connected,
             "name": agent_id.capitalize()

--- a/src/famiglia_core/command_center/backend/api/routes/connections.py
+++ b/src/famiglia_core/command_center/backend/api/routes/connections.py
@@ -135,10 +135,24 @@ async def get_slack_famiglia_status():
         socket_check = user_connections_store.get_connection_status(f"slack_socket:{agent_id}")
         bot_connected = bool(bot_check.get("connected"))
         socket_connected = bool(socket_check.get("connected"))
+        # Check transport mode
+        creds_conn = user_connections_store.get_connection(f"slack_creds:{agent_id}")
+        transport = "socket" # Default
+        public_url = None
+        if creds_conn:
+            try:
+                cdata = json.loads(creds_conn["access_token"])
+                transport = cdata.get("transport", "socket")
+                public_url = cdata.get("public_url")
+            except:
+                pass
+
         status[agent_id] = {
-            "connected": bot_connected,  # Installation is successful if bot token exists
+            "connected": bot_connected,
             "bot_connected": bot_connected,
             "socket_connected": socket_connected,
+            "transport": transport,
+            "public_url": public_url,
             "name": agent_id.capitalize()
         }
     return status

--- a/src/famiglia_core/command_center/backend/api/routes/connections.py
+++ b/src/famiglia_core/command_center/backend/api/routes/connections.py
@@ -1,4 +1,5 @@
 import os
+import json
 import requests as http_requests
 from fastapi import APIRouter, HTTPException
 from typing import Dict, Any

--- a/src/famiglia_core/command_center/backend/comms/slack/provisioning.py
+++ b/src/famiglia_core/command_center/backend/comms/slack/provisioning.py
@@ -83,7 +83,8 @@ class SlackProvisioningService:
                     
                     # 2. Set Redirect URI for OAuth bridge
                     # We always want this so we can use direct installation links
-                    base_url = (public_url or "http://localhost:3000").rstrip("/")
+                    # NOTE: Backend is on 8000, 3000 is Grafana.
+                    base_url = (public_url or "http://localhost:8000").rstrip("/")
                     callback_url = f"{base_url}/api/v1/connections/auth/slack/agent/callback"
                     
                     if 'oauth_config' not in manifest_data:
@@ -167,7 +168,7 @@ class SlackProvisioningService:
                     
                     if client_id:
                         # Direct OAuth logic: more straightforward than sending to API dashboard
-                        base_url = (public_url or "http://localhost:3000").rstrip("/")
+                        base_url = (public_url or "http://localhost:8000").rstrip("/")
                         redirect_uri = f"{base_url}/api/v1/connections/auth/slack/agent/callback"
                         install_url = (
                             f"https://slack.com/oauth/v2/authorize"

--- a/src/famiglia_core/command_center/backend/comms/slack/provisioning.py
+++ b/src/famiglia_core/command_center/backend/comms/slack/provisioning.py
@@ -157,7 +157,9 @@ class SlackProvisioningService:
                         access_token=json.dumps({
                             "client_id": creds.get("client_id"),
                             "client_secret": creds.get("client_secret"),
-                            "app_id": app_id
+                            "app_id": app_id,
+                            "transport": "http" if public_url else "socket",
+                            "public_url": public_url
                         }),
                         username=manifest_data["display_information"]["name"]
                     )

--- a/src/famiglia_core/command_center/backend/comms/slack/provisioning.py
+++ b/src/famiglia_core/command_center/backend/comms/slack/provisioning.py
@@ -81,19 +81,21 @@ class SlackProvisioningService:
                 try:
                     manifest_data = yaml.safe_load(f)
                     
-                    # TOTAL AUTOMATION INJECTION (Choice B)
-                    # If we have a public URL, we flip the app to HTTP mode
+                    # 2. Set Redirect URI for OAuth bridge
+                    # We always want this so we can use direct installation links
+                    base_url = (public_url or "http://localhost:3000").rstrip("/")
+                    callback_url = f"{base_url}/api/v1/connections/auth/slack/agent/callback"
+                    
+                    if 'oauth_config' not in manifest_data:
+                         manifest_data['oauth_config'] = {}
+                    manifest_data['oauth_config']['redirect_urls'] = [callback_url]
+
+                    # Choice B: HTTP Mode Configuration (if public URL is present)
                     if public_url:
                         # 1. Disable Socket Mode
                         if 'settings' not in manifest_data:
                             manifest_data['settings'] = {}
                         manifest_data['settings']['socket_mode_enabled'] = False
-                        
-                        # 2. Set Redirect URI for OAuth bridge
-                        callback_url = f"{public_url}/api/v1/connections/auth/slack/agent/callback"
-                        if 'oauth_config' not in manifest_data:
-                             manifest_data['oauth_config'] = {}
-                        manifest_data['oauth_config']['redirect_urls'] = [callback_url]
                         
                         # 3. Set Request URLs for Events & Interactivity
                         events_url = f"{public_url}/api/v1/comms/slack/events/{agent_id}"
@@ -162,9 +164,11 @@ class SlackProvisioningService:
                     # Construct Install URL
                     client_id = creds.get("client_id")
                     scopes = "app_mentions:read,chat:write,channels:history,groups:history,im:history,reactions:write,channels:read,groups:read,im:read"
-                    if public_url and client_id:
-                        # HTTP Mode: use full OAuth flow with redirect back to our server
-                        redirect_uri = f"{public_url}/api/v1/connections/auth/slack/agent/callback"
+                    
+                    if client_id:
+                        # Direct OAuth logic: more straightforward than sending to API dashboard
+                        base_url = (public_url or "http://localhost:3000").rstrip("/")
+                        redirect_uri = f"{base_url}/api/v1/connections/auth/slack/agent/callback"
                         install_url = (
                             f"https://slack.com/oauth/v2/authorize"
                             f"?client_id={client_id}"
@@ -173,9 +177,7 @@ class SlackProvisioningService:
                             f"&redirect_uri={redirect_uri}"
                         )
                     else:
-                        # Socket Mode: the OAuth URL adds redirect_uri= (empty) which Slack rejects.
-                        # The direct app settings page has a built-in "Install to Workspace"
-                        # button that bypasses this entirely — this is the correct Dev flow.
+                        # Fallback (shouldn't happen with Manifest API)
                         install_url = f"https://api.slack.com/apps/{app_id}"
 
                     app_info = {

--- a/src/famiglia_core/command_center/frontend/src/modules/Connections.tsx
+++ b/src/famiglia_core/command_center/frontend/src/modules/Connections.tsx
@@ -564,16 +564,14 @@ function SlackFamigliaWizard({ bossName }: { bossName: string }) {
                                     <h5 className="text-2xl font-headline font-black text-white">{app.name} Configuration</h5>
                                     <p className="text-xs font-body text-[#555]">App ID: <code className="text-[#a38b88]">{app.app_id}</code></p>
                                 </div>
-                                <div className="flex flex-col items-end gap-2">
-                                    <a
-                                        href={app.install_url}
-                                        target="_blank"
-                                        className="flex items-center gap-3 px-6 py-3 bg-white text-black text-xs font-black font-label uppercase tracking-widest rounded hover:bg-[#ffb3b5] transition-all shadow-[0_4px_20px_rgba(255,179,181,0.1)]"
-                                    >
-                                        <span className="material-symbols-outlined text-base">install_desktop</span>
-                                        Install App
-                                    </a>
-                                    <span className="text-[9px] font-label font-bold text-[#444] uppercase tracking-tighter">Step 1: Manifest the Agent</span>
+                                <div className="flex flex-col items-end gap-1">
+                                    <div className={`flex items-center gap-2 px-3 py-1 rounded-full border text-[10px] font-label font-bold uppercase tracking-widest ${
+                                        famigliaStatus[app.agent_id]?.connected ? 'border-emerald-900/60 bg-emerald-950/40 text-emerald-400' : 'border-white/5 bg-white/5 text-[#555]'
+                                    }`}>
+                                        <span className={`h-1.5 w-1.5 rounded-full ${famigliaStatus[app.agent_id]?.connected ? 'bg-emerald-400 shadow-[0_0_6px_#34d399]' : 'bg-[#444]'}`} />
+                                        {famigliaStatus[app.agent_id]?.connected ? 'Secured' : 'Pending'}
+                                    </div>
+                                    <span className="text-[9px] font-label font-bold text-[#444] uppercase tracking-tighter">Identity: {app.agent_id}</span>
                                 </div>
                             </div>
 

--- a/src/famiglia_core/command_center/frontend/src/modules/Connections.tsx
+++ b/src/famiglia_core/command_center/frontend/src/modules/Connections.tsx
@@ -565,11 +565,19 @@ function SlackFamigliaWizard({ bossName }: { bossName: string }) {
                                     <p className="text-xs font-body text-[#555]">App ID: <code className="text-[#a38b88]">{app.app_id}</code></p>
                                 </div>
                                 <div className="flex flex-col items-end gap-1">
-                                    <div className={`flex items-center gap-2 px-3 py-1 rounded-full border text-[10px] font-label font-bold uppercase tracking-widest ${
-                                        famigliaStatus[app.agent_id]?.connected ? 'border-emerald-900/60 bg-emerald-950/40 text-emerald-400' : 'border-white/5 bg-white/5 text-[#555]'
-                                    }`}>
-                                        <span className={`h-1.5 w-1.5 rounded-full ${famigliaStatus[app.agent_id]?.connected ? 'bg-emerald-400 shadow-[0_0_6px_#34d399]' : 'bg-[#444]'}`} />
-                                        {famigliaStatus[app.agent_id]?.connected ? 'Secured' : 'Pending'}
+                                    <div className="flex items-center gap-2">
+                                        {famigliaStatus[app.agent_id]?.connected && !famigliaStatus[app.agent_id]?.socket_connected && (
+                                            <div className="flex items-center gap-1.5 px-2 py-0.5 bg-amber-950/20 border border-amber-900/40 rounded-full text-[9px] font-label font-bold uppercase text-amber-400 tracking-tighter">
+                                                <span className="material-symbols-outlined text-[11px]">bolt_slash</span>
+                                                Socket Offline
+                                            </div>
+                                        )}
+                                        <div className={`flex items-center gap-2 px-3 py-1 rounded-full border text-[10px] font-label font-bold uppercase tracking-widest ${
+                                            famigliaStatus[app.agent_id]?.connected ? 'border-emerald-900/60 bg-emerald-950/40 text-emerald-400' : 'border-white/5 bg-white/5 text-[#555]'
+                                        }`}>
+                                            <span className={`h-1.5 w-1.5 rounded-full ${famigliaStatus[app.agent_id]?.connected ? 'bg-emerald-400 shadow-[0_0_6px_#34d399]' : 'bg-[#444]'}`} />
+                                            {famigliaStatus[app.agent_id]?.connected ? 'Authorized' : 'Pending'}
+                                        </div>
                                     </div>
                                     <span className="text-[9px] font-label font-bold text-[#444] uppercase tracking-tighter">Identity: {app.agent_id}</span>
                                 </div>
@@ -594,7 +602,12 @@ function SlackFamigliaWizard({ bossName }: { bossName: string }) {
                                         <div className="w-16 h-16 rounded-full bg-[#1cbb8c]/10 border border-[#1cbb8c]/20 flex items-center justify-center">
                                             <span className="material-symbols-outlined text-[#1cbb8c] text-3xl">check_circle</span>
                                         </div>
-                                        <span className="text-[10px] font-label font-black text-[#1cbb8c] uppercase tracking-[0.2em]">Connection Secured</span>
+                                        <div className="text-center">
+                                            <p className="text-[10px] font-label font-black text-[#1cbb8c] uppercase tracking-[0.2em]">Connection Authorized</p>
+                                            {!famigliaStatus[app.agent_id]?.socket_connected && (
+                                                <p className="text-[9px] font-body text-amber-400 opacity-60 mt-1 italic">Choice B (HTTP) active / Socket Offline</p>
+                                            )}
+                                        </div>
                                     </motion.div>
                                 ) : (
                                     <div className="flex flex-col items-center gap-4 w-full">

--- a/src/famiglia_core/command_center/frontend/src/modules/Connections.tsx
+++ b/src/famiglia_core/command_center/frontend/src/modules/Connections.tsx
@@ -566,11 +566,20 @@ function SlackFamigliaWizard({ bossName }: { bossName: string }) {
                                 </div>
                                 <div className="flex flex-col items-end gap-1">
                                     <div className="flex items-center gap-2">
-                                        {famigliaStatus[app.agent_id]?.connected && !famigliaStatus[app.agent_id]?.socket_connected && (
-                                            <div className="flex items-center gap-1.5 px-2 py-0.5 bg-amber-950/20 border border-amber-900/40 rounded-full text-[9px] font-label font-bold uppercase text-amber-400 tracking-tighter">
-                                                <span className="material-symbols-outlined text-[11px]">bolt_slash</span>
-                                                Socket Offline
-                                            </div>
+                                        {famigliaStatus[app.agent_id]?.connected && (
+                                            <>
+                                                {famigliaStatus[app.agent_id]?.transport === 'http' ? (
+                                                    <div className="flex items-center gap-1.5 px-2 py-0.5 bg-emerald-950/20 border border-emerald-900/40 rounded-full text-[9px] font-label font-bold uppercase text-emerald-500/80 tracking-tighter">
+                                                        <span className="material-symbols-outlined text-[11px]">webhook</span>
+                                                        Webhook Active
+                                                    </div>
+                                                ) : !famigliaStatus[app.agent_id]?.socket_connected && (
+                                                    <div className="flex items-center gap-1.5 px-2 py-0.5 bg-amber-950/20 border border-amber-900/40 rounded-full text-[9px] font-label font-bold uppercase text-amber-400 tracking-tighter">
+                                                        <span className="material-symbols-outlined text-[11px]">bolt_slash</span>
+                                                        Socket Offline
+                                                    </div>
+                                                )}
+                                            </>
                                         )}
                                         <div className={`flex items-center gap-2 px-3 py-1 rounded-full border text-[10px] font-label font-bold uppercase tracking-widest ${
                                             famigliaStatus[app.agent_id]?.connected ? 'border-emerald-900/60 bg-emerald-950/40 text-emerald-400' : 'border-white/5 bg-white/5 text-[#555]'

--- a/src/famiglia_core/db/schema.sql
+++ b/src/famiglia_core/db/schema.sql
@@ -257,7 +257,7 @@ CREATE TABLE IF NOT EXISTS user_connections (
   scopes       TEXT,
   connected_at TIMESTAMPTZ DEFAULT NOW(),
   updated_at   TIMESTAMPTZ DEFAULT NOW(),
-  UNIQUE (user_id, service)
+  UNIQUE (service)
 );
 
 CREATE INDEX IF NOT EXISTS idx_user_connections_lookup

--- a/tests/command_center/backend/api/test_connections_api.py
+++ b/tests/command_center/backend/api/test_connections_api.py
@@ -179,3 +179,47 @@ class TestDisconnectService:
         mock_store.delete_connection.return_value = False
         response = client.delete("/api/v1/connections/ollama")
         assert response.status_code == 500
+
+
+# ─── GET /connections/slack/status ───────────────────────────────────────────
+
+class TestGetSlackFamigliaStatus:
+    @patch(CONNECTIONS_STORE)
+    def test_status_reports_http_transport(self, mock_store):
+        # Mock connections: bot connected, no socket, but transport is HTTP
+        import json
+        def get_conn_side_effect(service):
+            if service == "slack_bot:alfredo":
+                return {"access_token": "token"}
+            if service == "slack_creds:alfredo":
+                return {"access_token": json.dumps({"transport": "http", "public_url": "https://tunnel.me"})}
+            return None
+            
+        mock_store.get_connection.side_effect = get_conn_side_effect
+        mock_store.get_connection_status.side_effect = lambda s: {"connected": True} if "bot:alfredo" in s else {"connected": False}
+
+        response = client.get("/api/v1/connections/slack/status")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["alfredo"]["connected"] is True
+        assert data["alfredo"]["transport"] == "http"
+        assert data["alfredo"]["public_url"] == "https://tunnel.me"
+        assert data["alfredo"]["socket_connected"] is False
+
+    @patch(CONNECTIONS_STORE)
+    def test_status_reports_socket_transport(self, mock_store):
+        import json
+        def get_conn_side_effect(service):
+            if "bot:riccardo" in service: return {"access_token": "token"}
+            if service == "slack_creds:riccardo":
+                return {"access_token": json.dumps({"transport": "socket"})}
+            return None
+            
+        mock_store.get_connection.side_effect = get_conn_side_effect
+        mock_store.get_connection_status.return_value = {"connected": True}
+
+        response = client.get("/api/v1/connections/slack/status")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["riccardo"]["transport"] == "socket"
+        assert data["riccardo"]["socket_connected"] is True

--- a/tests/command_center/backend/comms/slack/test_provisioning.py
+++ b/tests/command_center/backend/comms/slack/test_provisioning.py
@@ -93,7 +93,8 @@ settings:
             app_info = result[0]
             assert app_info["agent_id"] == "test_agent"
             assert app_info["app_id"] == "A12345678"
-            assert "https://api.slack.com/apps/A12345678" in app_info["install_url"]
+            assert "oauth/v2/authorize" in app_info["install_url"]
+            assert "client_id=client_123" in app_info["install_url"]
 
             # Ensures DB upsert was called
             mock_store.upsert_connection.assert_called()

--- a/tests/command_center/backend/slack/test_slack_provisioning_service.py
+++ b/tests/command_center/backend/slack/test_slack_provisioning_service.py
@@ -1,0 +1,85 @@
+import pytest
+import json
+import yaml
+from unittest.mock import MagicMock, patch, mock_open
+from famiglia_core.command_center.backend.comms.slack.provisioning import SlackProvisioningService
+
+class TestSlackProvisioningService:
+    @pytest.fixture
+    def service(self):
+        return SlackProvisioningService()
+
+    @patch("famiglia_core.command_center.backend.comms.slack.provisioning.os.listdir")
+    @patch("famiglia_core.command_center.backend.comms.slack.provisioning.os.path.exists")
+    @patch("famiglia_core.command_center.backend.comms.slack.provisioning.WebClient")
+    @patch("famiglia_core.command_center.backend.comms.slack.provisioning.user_connections_store")
+    def test_provision_http_mode_detection(self, mock_store, mock_web_client_cls, mock_exists, mock_listdir, service):
+        # Mocking
+        mock_listdir.return_value = ["alfredo.yaml"]
+        mock_exists.return_value = True
+        mock_client = MagicMock()
+        mock_web_client_cls.return_value = mock_client
+        
+        # Manifest content
+        dummy_manifest = {
+            "display_information": {"name": "Alfredo"},
+            "settings": {"socket_mode_enabled": True}
+        }
+        
+        # Mock public URL (Choice B)
+        with patch.object(service, "_get_public_url", return_value="https://famiglia.ngrok.io"):
+            with patch("builtins.open", mock_open(read_data=yaml.dump(dummy_manifest))):
+                mock_client.apps_manifest_create.return_value = {
+                    "ok": True,
+                    "app_id": "A123",
+                    "credentials": {"client_id": "C123", "client_secret": "S123"}
+                }
+                
+                service.provision_famiglia(app_level_token="xapp-test")
+                
+                # Verify manifest patching
+                args = mock_client.apps_manifest_create.call_args[1]["manifest"]
+                manifest_data = yaml.safe_load(args)
+                assert manifest_data["settings"]["socket_mode_enabled"] is False
+                
+                # Verify metadata storage
+                mock_store.upsert_connection.assert_called()
+                call_args = mock_store.upsert_connection.call_args[1]
+                metadata = json.loads(call_args["access_token"])
+                assert metadata["transport"] == "http"
+                assert metadata["public_url"] == "https://famiglia.ngrok.io"
+
+    @patch("famiglia_core.command_center.backend.comms.slack.provisioning.os.listdir")
+    @patch("famiglia_core.command_center.backend.comms.slack.provisioning.WebClient")
+    @patch("famiglia_core.command_center.backend.comms.slack.provisioning.user_connections_store")
+    def test_provision_socket_mode_fallback(self, mock_store, mock_web_client_cls, mock_listdir, service):
+        mock_listdir.return_value = ["alfredo.yaml"]
+        mock_client = MagicMock()
+        mock_web_client_cls.return_value = mock_client
+        
+        dummy_manifest = {
+            "display_information": {"name": "Alfredo"},
+            "settings": {"socket_mode_enabled": True}
+        }
+        
+        # No public URL (Choice A)
+        with patch.object(service, "_get_public_url", return_value=None):
+            with patch("builtins.open", mock_open(read_data=yaml.dump(dummy_manifest))):
+                mock_client.apps_manifest_create.return_value = {
+                    "ok": True,
+                    "app_id": "A123",
+                    "credentials": {"client_id": "C123", "client_secret": "S123"}
+                }
+                
+                service.provision_famiglia(app_level_token="xapp-test")
+                
+                # Verify socket mode kept
+                args = mock_client.apps_manifest_create.call_args[1]["manifest"]
+                manifest_data = yaml.safe_load(args)
+                assert manifest_data["settings"]["socket_mode_enabled"] is True
+                
+                # Verify metadata storage
+                call_args = mock_store.upsert_connection.call_args[1]
+                metadata = json.loads(call_args["access_token"])
+                assert metadata["transport"] == "socket"
+                assert metadata["public_url"] is None

--- a/tests/db/test_user_connections_store.py
+++ b/tests/db/test_user_connections_store.py
@@ -3,6 +3,7 @@ Tests for UserConnectionsStore — Fernet encryption, upsert, get, delete.
 All DB calls and Fernet key loading are mocked to keep tests hermetic.
 """
 import pytest
+import json
 from unittest.mock import patch, MagicMock
 from cryptography.fernet import Fernet
 
@@ -119,6 +120,26 @@ class TestUpsertConnection:
         with patch("famiglia_core.db.tools.user_connections_store.context_store.db_session", return_value=cm):
             result = store.upsert_connection(service="ollama", access_token="key")
         assert result is False
+
+    def test_on_conflict_targets_service(self, store, mock_db_session):
+        _, cursor = mock_db_session
+        store.upsert_connection(service="slack_bot:alfredo", access_token="token")
+        sql = cursor.execute.call_args[0][0].upper()
+        # Verify the ON CONFLICT clause targets only the service column now
+        assert "ON CONFLICT (SERVICE)" in sql
+        assert "USER_ID" not in sql.split("ON CONFLICT")[1]
+
+    def test_stores_metadata_as_scopes(self, store, mock_db_session):
+        _, cursor = mock_db_session
+        metadata = {"transport": "http", "public_url": "https://ngrok.io"}
+        store.upsert_connection(
+            service="slack_creds:alfredo", 
+            access_token="{}", 
+            scopes=json.dumps(metadata)
+        )
+        call_args = cursor.execute.call_args[0][1]
+        stored_metadata = call_args[4] # scopes is the 5th param
+        assert json.loads(stored_metadata)["transport"] == "http"
 
 
 # ─── get_connection ───────────────────────────────────────────────────────────


### PR DESCRIPTION
# Description
This PR is meant to:
1. Streamline Slack Integration for all 8 Slack bots created
2. adjust tests


# Checklist
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (i.e. `README.md` files)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
