### PR TITLE
feat: ensure Alfredo joins Slack channels before inviting agents and improve error handling for invitations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# [1.16.0](https://github.com/AI-Passione/famiglia-core/compare/v1.15.0...v1.16.0) (2026-04-20)
+
+### UI/UX Enhancements
+* **Automated Slack Onboarding**: Implemented auto-refresh logic in the Slack provisioner. The page now automatically redirects once all 8 agents are successfully authorized, streamlining the "Assembly" process.
+* **Premium Feedback**: Added visual states to the progress bar and status text ("All Agents Secured!", "Redirecting...") to provide a smooth, premium transition experience.
+
 # [1.15.0](https://github.com/AI-Passione/famiglia-core/compare/v1.14.0...v1.15.0) (2026-04-17)
 
 ### Slack Workspace Organization 2.0

--- a/src/famiglia_core/command_center/backend/comms/slack/provisioning.py
+++ b/src/famiglia_core/command_center/backend/comms/slack/provisioning.py
@@ -300,7 +300,7 @@ class SlackProvisioningService:
                     client_id = creds.get("client_id")
                     scopes = (
                         "app_mentions:read,chat:write,channels:history,groups:history,im:history,"
-                        "reactions:write,channels:read,groups:read,im:read,channels:manage,groups:write,users:read"
+                        "reactions:write,channels:read,groups:read,im:read,channels:manage,channels:join,groups:write,users:read"
                     )
                     
                     if client_id:

--- a/src/famiglia_core/command_center/backend/comms/slack/provisioning.py
+++ b/src/famiglia_core/command_center/backend/comms/slack/provisioning.py
@@ -272,14 +272,27 @@ class SlackProvisioningService:
                         app_id = None
                         creds = {}
 
+                response = None
                 if app_id:
                     print(f"🔄 Syncing existing {agent_id} (App ID: {app_id})...")
-                    response = client.apps_manifest_update(app_id=app_id, manifest=manifest_str)
-                else:
+                    try:
+                        response = client.apps_manifest_update(app_id=app_id, manifest=manifest_str)
+                    except SlackApiError as e:
+                        error_code = e.response['error']
+                        # If the app is missing or Slack returns an internal error (usually due to stale IDs),
+                        # we purge the local reference and fall back to the creation flow.
+                        if error_code in ["app_not_found", "internal_error", "access_denied"]:
+                            print(f"⚠️ App {app_id} is stale or inaccessible ({error_code}). Purging and re-creating...")
+                            user_connections_store.delete_connection(f"slack_creds:{agent_id}")
+                            app_id = None
+                        else:
+                            raise e
+
+                if not app_id:
                     print(f"📦 Manifesting new {agent_id}...")
                     response = client.apps_manifest_create(manifest=manifest_str)
                 
-                if response["ok"]:
+                if response and response["ok"]:
                     if not app_id:
                         app_id = response["app_id"]
                         creds = response.get("credentials", {})
@@ -323,10 +336,11 @@ class SlackProvisioningService:
                         "install_url": install_url
                     }
                     provisioned_apps.append(app_info)
-                    status_icon = "✅ Updated" if existing_creds else "✅ Created"
+                    status_icon = "✅ Updated" if existing_creds and app_id else "✅ Created"
                     print(f"{status_icon} {agent_id} (App ID: {app_id})")
                 else:
-                    print(f"❌ Failed to process {agent_id}: {response['error']}")
+                    err = response["error"] if response else "Unknown Error"
+                    print(f"❌ Failed to process {agent_id}: {err}")
             except SlackApiError as e:
                 error_code = e.response['error']
                 print(f"❌ Slack API Error for {agent_id}: {error_code}")
@@ -350,6 +364,7 @@ class SlackProvisioningService:
                                 print(f"❌ Retry failed for {agent_id}: {re}")
             except Exception as e:
                 print(f"❌ Unexpected error manifesting {agent_id}: {e}")
+
                 
         return provisioned_apps
 

--- a/src/famiglia_core/command_center/backend/comms/slack/provisioning.py
+++ b/src/famiglia_core/command_center/backend/comms/slack/provisioning.py
@@ -569,6 +569,14 @@ class SlackProvisioningService:
             if channel_id:
                 actual_agents_joined = []
                 
+                # IMPORTANT: Alfredo MUST join the channel first to invite others
+                try:
+                    client.conversations_join(channel=channel_id)
+                except SlackApiError as e:
+                    join_error = e.response["error"]
+                    if join_error != "already_in_channel":
+                        print(f"⚠️ Alfredo failed to join #{desired_name}: {join_error}")
+
                 # Invite Owner first
                 if owner_id:
                     try:
@@ -586,12 +594,15 @@ class SlackProvisioningService:
                         # Alfredo invites the bot
                         client.conversations_invite(channel=channel_id, users=bot_user_id)
                         actual_agents_joined.append(agent_id)
+                        print(f"  + Invited {agent_id} to #{desired_name}")
                     except SlackApiError as e:
+                        invite_err = e.response["error"]
                         # Often "already_in_channel" or "cant_invite_self", which we can ignore
-                        if e.response["error"] not in ["already_in_channel", "cant_invite_self"]:
-                            results["errors"].append(f"Invite {agent_id} to #{desired_name} failed: {e.response['error']}")
-                        else:
+                        if invite_err in ["already_in_channel", "cant_invite_self"]:
                             actual_agents_joined.append(agent_id)
+                        else:
+                            print(f"⚠️ Failed to invite {agent_id} to #{desired_name}: {invite_err}")
+                            results["errors"].append(f"Invite {agent_id} to #{desired_name} failed: {invite_err}")
                 
                 results["channels"].append({
                     "code": code,

--- a/src/famiglia_core/command_center/frontend/src/modules/Connections.tsx
+++ b/src/famiglia_core/command_center/frontend/src/modules/Connections.tsx
@@ -355,6 +355,19 @@ function SlackFamigliaWizard({ bossName, onClose, onHardReset }: { bossName: str
     }
   }, [step]);
 
+  // Auto-refresh when all 8 bots are successfully authorized
+  useEffect(() => {
+    if (step === 2 && provisionedApps.length === 8) {
+      const connectedCount = Object.values(famigliaStatus).filter((s: any) => s.connected).length;
+      if (connectedCount === 8) {
+        const timer = setTimeout(() => {
+          window.location.reload();
+        }, 1500);
+        return () => clearTimeout(timer);
+      }
+    }
+  }, [famigliaStatus, provisionedApps, step]);
+
   const fetchFamigliaStatus = async () => {
     try {
       const res = await fetch(`${API_BASE}/connections/slack/status`);
@@ -560,21 +573,23 @@ function SlackFamigliaWizard({ bossName, onClose, onHardReset }: { bossName: str
 
                 <div className="space-y-4 relative z-10">
                    <div className="flex items-center justify-between text-[11px] font-label font-black text-[#a38b88] uppercase tracking-widest px-1">
-                      <span>Global Synchronizing</span>
-                      <span className="text-[#ffb3b5]">Ready for Securing</span>
+                      <span>{Object.values(famigliaStatus).filter((s:any) => s.connected).length === provisionedApps.length ? 'All Agents Secured!' : 'Global Synchronizing'}</span>
+                      <span className="text-[#ffb3b5]">{Object.values(famigliaStatus).filter((s:any) => s.connected).length === provisionedApps.length ? 'Redirecting...' : 'Ready for Securing'}</span>
                    </div>
                    <div className="h-2 w-full bg-[#0d0d0d] rounded-full overflow-hidden border border-white/5 shadow-inner p-[1px]">
                       <motion.div 
                         initial={{ width: 0 }}
                         animate={{ width: `${(Object.values(famigliaStatus).filter((s:any) => s.connected).length / provisionedApps.length) * 100}%` }}
                         transition={{ duration: 1.5, ease: "easeOut" }}
-                        className="h-full rounded-full bg-gradient-to-r from-[#6366f1] via-[#a855f7] to-[#ffb3b5] relative"
+                        className={`h-full rounded-full ${Object.values(famigliaStatus).filter((s:any) => s.connected).length === provisionedApps.length ? 'bg-emerald-400 shadow-[0_0_15px_#34d399]' : 'bg-gradient-to-r from-[#6366f1] via-[#a855f7] to-[#ffb3b5]'} relative`}
                       >
                          <div className="absolute inset-0 bg-white/20 animate-pulse" />
                       </motion.div>
                    </div>
                    <p className="text-[11px] font-body text-[#555] italic text-center">
-                     {bossName}, the network has been mapped. Secure each spirit below to finalize the integration.
+                     {Object.values(famigliaStatus).filter((s:any) => s.connected).length === provisionedApps.length 
+                       ? `${bossName}, the network is fully stabilized. Handover initiated.`
+                       : `${bossName}, the network has been mapped. Secure each spirit below to finalize the integration.`}
                    </p>
                 </div>
               </div>


### PR DESCRIPTION
# Description
This PR is meant to:
1.  enhance the Slack integration and have auto re-creation for Slack bot if it doesn't exist yet.
2.  Also add "channal:join" in Manifest for all Slack bots

# Checklist
- [x] I have performed a self-review of my own code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass **locally** with my changes
- [x] I have made corresponding changes to the documentation (i.e. `README.md` files)
- [ ] I have commented my code, particularly in hard-to-understand areas