### PR TITLE
feat: persist resolved Slack channel ID to database during provisioning if not already stored

### DIFF
--- a/src/famiglia_core/command_center/backend/comms/slack/provisioning.py
+++ b/src/famiglia_core/command_center/backend/comms/slack/provisioning.py
@@ -77,6 +77,8 @@ class SlackProvisioningService:
                         "channel_name": config["name"]
                     }
                 )
+            else:
+                print(f"  - Skipping greeting (already exists): {title}")
 
     def _get_public_url(self) -> Optional[str]:
         """Fetch the public URL from environment or ngrok container's API."""

--- a/src/famiglia_core/command_center/backend/comms/slack/provisioning.py
+++ b/src/famiglia_core/command_center/backend/comms/slack/provisioning.py
@@ -580,6 +580,14 @@ class SlackProvisioningService:
                     except SlackApiError as e:
                         results["errors"].append(f"Failed to rename #{desired_name}: {e.response['error']}")
 
+            # Persist resolved ID if it wasn't already in DB
+            if channel_id and not stored_ref:
+                user_connections_store.upsert_connection(
+                    service=f"slack_channel:{code}",
+                    access_token=channel_id,
+                    username=desired_name
+                )
+
             # Join bots & owner
             if channel_id:
                 actual_agents_joined = []


### PR DESCRIPTION
# Description
This PR is meant to:
1. make sure the seeding of AI agent greeting in Slack works as expected
2. improve loggings to say it out loud if the greeting in Slack were already done before and skipping so


# Checklist
- [x] I have performed a self-review of my own code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass **locally** with my changes
- [ ] I have made corresponding changes to the documentation (i.e. `README.md` files)
- [ ] I have commented my code, particularly in hard-to-understand areas