### PR TITLE
fix: introduce `is_scheduled` flag

### DIFF
--- a/src/famiglia_core/agents/orchestration/scheduler.py
+++ b/src/famiglia_core/agents/orchestration/scheduler.py
@@ -153,6 +153,7 @@ class TaskOrchestrator:
             eta_pickup_at=now,  # Pass datetime object directly
             metadata=task.metadata,
             recurring_task_id=task.id,
+            is_scheduled=True,
         )
         context_store.update_recurring_task_last_spawned(task.id, now)
         self._wakeup_event.set() # Wake up the worker immediately

--- a/src/famiglia_core/command_center/backend/api/main.py
+++ b/src/famiglia_core/command_center/backend/api/main.py
@@ -96,6 +96,7 @@ class TaskInstance(BaseModel):
     eta_completion_at: Optional[datetime] = None
     completed_at: Optional[datetime] = None
     result_summary: Optional[str] = None
+    is_scheduled: bool = False
 
 class RecurringTaskTemplate(BaseModel):
     id: int

--- a/src/famiglia_core/command_center/backend/api/routes/agenda.py
+++ b/src/famiglia_core/command_center/backend/api/routes/agenda.py
@@ -19,6 +19,7 @@ class AgendaEvent(BaseModel):
     priority: str
     expected_agent: Optional[str] = None
     metadata: Dict[str, Any] = Field(default_factory=dict)
+    is_scheduled: bool = False
 
     # Adding user-friendly aliases for Google Calendar style consumption if needed
     @property
@@ -92,7 +93,8 @@ async def create_agenda_event(request: AgendaCreateRequest):
         expected_agent=request.agent_id,
         eta_pickup_at=request.start,
         eta_completion_at=request.end,
-        metadata=metadata
+        metadata=metadata,
+        is_scheduled=True
     )
     
     if not task:

--- a/src/famiglia_core/command_center/frontend/src/App.tsx
+++ b/src/famiglia_core/command_center/frontend/src/App.tsx
@@ -151,62 +151,62 @@ function App() {
     return () => clearTimeout(sync);
   }, [settings, settingsHydrated]);
 
-  useEffect(() => {
-    const fetchData = async () => {
-      try {
-        const [agentsRes, actionsRes, tasksRes, recurringTasksRes] = await Promise.all([
-          fetch(`${API_BASE}/agents`),
-          fetch(`${API_BASE}/actions?limit=24`),
-          fetch(`${API_BASE}/tasks?limit=1000`), // Force rebuild: updated limit and sorting logic
-          fetch(`${API_BASE}/recurring-tasks`)
-        ]);
-        
-        if (agentsRes.ok) {
-          const data = await agentsRes.json();
-          setAgents(Array.isArray(data) ? data : []);
-        }
-        if (actionsRes.ok) {
-          const data = await actionsRes.json() as PaginatedActions;
-          setActions(Array.isArray(data.actions) ? data.actions : []);
-        }
-        if (tasksRes.ok) {
-          const data = await tasksRes.json() as PaginatedTasks;
-          setTasks(Array.isArray(data.tasks) ? data.tasks : []);
-        }
-        if (recurringTasksRes.ok) {
-          const data = await recurringTasksRes.json();
-          setRecurringTasks(Array.isArray(data) ? data : []);
-        }
-      } catch (err) {
-        console.error("Failed to fetch data:", err);
+  const fetchData = useCallback(async () => {
+    try {
+      const [agentsRes, actionsRes, tasksRes, recurringTasksRes] = await Promise.all([
+        fetch(`${API_BASE}/agents`),
+        fetch(`${API_BASE}/actions?limit=24`),
+        fetch(`${API_BASE}/tasks?limit=1000`), 
+        fetch(`${API_BASE}/recurring-tasks`)
+      ]);
+      
+      if (agentsRes.ok) {
+        const data = await agentsRes.json();
+        setAgents(Array.isArray(data) ? data : []);
       }
-    };
+      if (actionsRes.ok) {
+        const data = await actionsRes.json() as PaginatedActions;
+        setActions(Array.isArray(data.actions) ? data.actions : []);
+      }
+      if (tasksRes.ok) {
+        const data = await tasksRes.json() as PaginatedTasks;
+        setTasks(Array.isArray(data.tasks) ? data.tasks : []);
+      }
+      if (recurringTasksRes.ok) {
+        const data = await recurringTasksRes.json();
+        setRecurringTasks(Array.isArray(data) ? data : []);
+      }
+    } catch (err) {
+      console.error("Failed to fetch data:", err);
+    }
+  }, []);
 
-    const fetchGraphs = async () => {
-      try {
-        const response = await fetch(`${API_BASE}/operations/graphs`);
-        if (response.ok) {
-          const data = await response.json();
-          const validGraphs = Array.isArray(data) ? data : [];
-          setGraphs(validGraphs);
-          if (validGraphs.length > 0 && !selectedGraph) {
-            setSelectedGraph(validGraphs[0]);
-          }
-        } else {
-          setGraphs([]);
+  const fetchGraphs = useCallback(async () => {
+    try {
+      const response = await fetch(`${API_BASE}/operations/graphs`);
+      if (response.ok) {
+        const data = await response.json();
+        const validGraphs = Array.isArray(data) ? data : [];
+        setGraphs(validGraphs);
+        if (validGraphs.length > 0 && !selectedGraph) {
+          setSelectedGraph(validGraphs[0]);
         }
-      } catch (error) {
-        console.error("Failed to fetch graphs:", error);
+      } else {
         setGraphs([]);
       }
-    };
+    } catch (error) {
+      console.error("Failed to fetch graphs:", error);
+      setGraphs([]);
+    }
+  }, [selectedGraph]);
 
+  useEffect(() => {
     fetchData(); // Initial fetch for agents, actions, tasks
     fetchGraphs(); // Initial fetch for graphs
 
     const interval = setInterval(fetchData, 5000); // Set up interval for recurring data fetch
     return () => clearInterval(interval); // Cleanup interval on unmount
-  }, [selectedGraph]);
+  }, [fetchData, fetchGraphs]);
 
   return (
     <ToastProvider>
@@ -234,6 +234,7 @@ function App() {
                       honorific={settings.honorific}
                       fullName={settings.fullName}
                       graphs={graphs}
+                      onRefresh={fetchData}
                     />
                   } 
                 />
@@ -290,6 +291,7 @@ function App() {
           isOpen={isDirectiveModalOpen} 
           onClose={() => setDirectiveModalOpen(false)} 
           graphs={graphs}
+          onRefresh={fetchData}
         />
         <div className="fixed left-72 top-16 w-[1px] h-full bg-[#1c1b1b] z-30"></div>
       </div>

--- a/src/famiglia_core/command_center/frontend/src/modules/Agenda.tsx
+++ b/src/famiglia_core/command_center/frontend/src/modules/Agenda.tsx
@@ -14,6 +14,7 @@ interface AgendaProps {
   honorific: string;
   fullName: string;
   graphs: GraphDefinition[];
+  onRefresh?: () => void;
 }
 
 const VIEW_OPTIONS: Array<{ id: AgendaView; label: string }> = [
@@ -740,6 +741,7 @@ export function Agenda({
   honorific,
   fullName,
   graphs,
+  onRefresh,
 }: AgendaProps) {
   const navigate = useNavigate();
   const [view, setView] = useState<AgendaView>('month');
@@ -1127,7 +1129,7 @@ export function Agenda({
         isOpen={isEventModalOpen}
         onClose={() => setEventModalOpen(false)}
         onSuccess={() => {
-          // Data will refresh via the interval in App.tsx
+          onRefresh?.();
         }}
         agents={agents}
         graphs={graphs}

--- a/src/famiglia_core/command_center/frontend/src/modules/Agenda.tsx
+++ b/src/famiglia_core/command_center/frontend/src/modules/Agenda.tsx
@@ -178,6 +178,7 @@ function buildTaskEntries(tasks: Task[], rangeStart: Date, rangeEnd: Date): Agen
     const start = getTaskStart(task);
     if (!start) return collection;
     if (start < rangeStart || start > rangeEnd) return collection;
+    if (!task.is_scheduled) return collection;
 
     collection.push({
       id: `task-${task.id}`,

--- a/src/famiglia_core/command_center/frontend/src/modules/ui/DirectiveModal.tsx
+++ b/src/famiglia_core/command_center/frontend/src/modules/ui/DirectiveModal.tsx
@@ -9,9 +9,10 @@ interface DirectiveModalProps {
   isOpen: boolean;
   onClose: () => void;
   graphs: GraphDefinition[];
+  onRefresh?: () => void;
 }
 
-export function DirectiveModal({ isOpen, onClose, graphs }: DirectiveModalProps) {
+export function DirectiveModal({ isOpen, onClose, graphs, onRefresh }: DirectiveModalProps) {
   const [selectedGraphId, setSelectedGraphId] = useState<string | null>(null);
   const [activeCategory, setActiveCategory] = useState<string | null>(null);
   const [manualPrompt, setManualPrompt] = useState('');
@@ -52,6 +53,7 @@ export function DirectiveModal({ isOpen, onClose, graphs }: DirectiveModalProps)
           addExternalAgentMessage(data.acknowledgement, data.agent_id);
         }
         
+        onRefresh?.();
         setExecuting(false);
       } else {
         showToast('Failed to dispatch directive.', 'error');

--- a/src/famiglia_core/command_center/frontend/src/types.ts
+++ b/src/famiglia_core/command_center/frontend/src/types.ts
@@ -42,6 +42,7 @@ export interface Task {
   recurring_task_id?: number | null;
   metadata?: Record<string, unknown> | null;
   error_details?: string | null;
+  is_scheduled?: boolean;
 }
 
 export type AgendaEntryKind = 'task' | 'recurring';

--- a/src/famiglia_core/db/agents/context_store.py
+++ b/src/famiglia_core/db/agents/context_store.py
@@ -572,6 +572,7 @@ class AgentContextStore:
         eta_completion_at: Optional[datetime] = None,
         metadata: Optional[Dict[str, Any]] = None,
         recurring_task_id: Optional[int] = None,
+        is_scheduled: bool = False,
     ) -> Optional[Dict[str, Any]]:
         safe_priority = self._normalize_priority(priority)
         safe_created_by = self._normalize_creator_type(created_by_type)
@@ -588,11 +589,11 @@ class AgentContextStore:
                         title, task_payload, status, priority,
                         created_by_type, created_by_name,
                         expected_agent, eta_pickup_at, eta_completion_at,
-                        metadata, recurring_task_id, created_at, updated_at
-                    ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, NOW(), NOW())
+                        metadata, recurring_task_id, is_scheduled, created_at, updated_at
+                    ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, NOW(), NOW())
                     RETURNING *
                     """,
-                    (title, task_payload, "queued", safe_priority, safe_created_by, created_by_name, expected_agent, eta_pickup_at, eta_completion_at, self._safe_json(metadata), recurring_task_id),
+                    (title, task_payload, "queued", safe_priority, safe_created_by, created_by_name, expected_agent, eta_pickup_at, eta_completion_at, self._safe_json(metadata), recurring_task_id, is_scheduled),
                 )
                 row = cursor.fetchone()
                 return self._serialize_task_row(row) if row else None
@@ -691,6 +692,7 @@ class AgentContextStore:
         start_date: datetime,
         end_date: datetime,
         statuses: Optional[List[str]] = None,
+        only_scheduled: bool = True,
     ) -> List[Dict[str, Any]]:
         """Fetch tasks that fall within a specific time range for the Agenda view."""
         normalized_statuses = self._normalize_statuses(statuses)
@@ -705,6 +707,9 @@ class AgentContextStore:
         if normalized_statuses:
             query += " AND status = ANY(%s)"
             params.append(normalized_statuses)
+
+        if only_scheduled:
+            query += " AND is_scheduled = TRUE"
             
         query += " ORDER BY eta_pickup_at ASC"
         

--- a/src/famiglia_core/db/schema.sql
+++ b/src/famiglia_core/db/schema.sql
@@ -163,6 +163,7 @@ CREATE TABLE IF NOT EXISTS task_instances (
   result_summary TEXT,
   error_details TEXT,
   metadata JSONB,
+  is_scheduled BOOLEAN DEFAULT FALSE,
   created_at TIMESTAMPTZ DEFAULT NOW(),
   updated_at TIMESTAMPTZ DEFAULT NOW(),
   CHECK (status IN ('queued', 'in_progress', 'drafted', 'completed', 'failed', 'cancelled')),


### PR DESCRIPTION
# Description
This PR is meant to:
1.  add a new `is_scheduled` flag to be used everywhere
2. Only show Scheduled Tasks in the Agenda tab to have a lot clearer view
3. adjust test

# Checklist
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass **locally** with my changes
- [ ] I have made corresponding changes to the documentation (i.e. `README.md` files)
- [ ] I have commented my code, particularly in hard-to-understand areas